### PR TITLE
Update package.ini for Plasma 6

### DIFF
--- a/package.ini
+++ b/package.ini
@@ -15,6 +15,6 @@ package[] = xf86-video-amdgpu
 [Desktop]
 package[] = libqt5-qtbase/libQt5Core5
 package[] = plasma-framework
-package[] = plasma5-workspace
+package[] = plasma6-desktop
 ; does not appear to be an applications base or meta package
 package[] = kate@openSUSE_Factory_standard


### PR DESCRIPTION
The Plasma5 line on [the hosted version](http://tumbleweed.boombatower.com/) of this is now blank.  I believe this is the correct package to update it to now that we're on Plasma 6 instead of 5.